### PR TITLE
Add Tailscale support to the OpenClaw container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,22 @@ RUN apt-get update \
     curl \
     git \
     gosu \
+    gnupg \
+    iptables \
+    iproute2 \
     procps \
     python3 \
     build-essential \
     zip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN install -d -m 0755 /usr/share/keyrings \
+  && curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
+       -o /usr/share/keyrings/tailscale-archive-keyring.gpg \
+  && curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list \
+       -o /etc/apt/sources.list.d/tailscale.list \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tailscale \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g openclaw@2026.5.2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,11 +4,75 @@ set -e
 chown -R openclaw:openclaw /data
 chmod 700 /data
 
+TS_DIR=/data/tailscale
+mkdir -p "$TS_DIR"
+chown -R root:root "$TS_DIR"
+chmod 700 "$TS_DIR"
+
 if [ ! -d /data/.linuxbrew ]; then
   cp -a /home/linuxbrew/.linuxbrew /data/.linuxbrew
 fi
 
 rm -rf /home/linuxbrew/.linuxbrew
 ln -sfn /data/.linuxbrew /home/linuxbrew/.linuxbrew
+
+start_tailscale() {
+  if ! command -v tailscaled >/dev/null 2>&1; then
+    echo "[tailscale] tailscaled binary not present, skipping"
+    return 0
+  fi
+
+  echo "[tailscale] starting tailscaled (userspace networking)"
+  tailscaled \
+    --state="$TS_DIR/tailscaled.state" \
+    --socket="$TS_DIR/tailscaled.sock" \
+    --tun=userspace-networking \
+    --socks5-server=localhost:1055 \
+    --outbound-http-proxy-listen=localhost:1055 \
+    >>"$TS_DIR/tailscaled.log" 2>&1 &
+
+  local i
+  for i in $(seq 1 30); do
+    [ -S "$TS_DIR/tailscaled.sock" ] && break
+    sleep 1
+  done
+
+  if [ ! -S "$TS_DIR/tailscaled.sock" ]; then
+    echo "[tailscale] tailscaled did not become ready; last log lines:"
+    tail -n 20 "$TS_DIR/tailscaled.log" 2>/dev/null || true
+    return 0
+  fi
+
+  if [ -n "${TS_AUTHKEY:-}" ]; then
+    local hostname="${TS_HOSTNAME:-openclaw-railway}"
+    echo "[tailscale] tailscale up (hostname=$hostname)"
+    if tailscale --socket="$TS_DIR/tailscaled.sock" up \
+        --authkey="$TS_AUTHKEY" \
+        --hostname="$hostname" \
+        --accept-dns="${TS_ACCEPT_DNS:-false}" \
+        ${TS_EXTRA_ARGS:-}; then
+      echo "[tailscale] authenticated successfully"
+    else
+      echo "[tailscale] tailscale up failed; check $TS_DIR/tailscaled.log"
+      return 0
+    fi
+
+    if [ "${TS_SERVE_DISABLED:-false}" != "true" ]; then
+      local serve_port="${TS_SERVE_PORT:-${PORT:-8080}}"
+      echo "[tailscale] tailscale serve -> http://localhost:$serve_port"
+      tailscale --socket="$TS_DIR/tailscaled.sock" serve reset 2>/dev/null || true
+      tailscale --socket="$TS_DIR/tailscaled.sock" serve --bg \
+        "http://localhost:$serve_port" \
+        || echo "[tailscale] serve failed (node still reachable on tailnet IP:$serve_port)"
+    fi
+
+    tailscale --socket="$TS_DIR/tailscaled.sock" status --peers=false 2>/dev/null || true
+  else
+    echo "[tailscale] TS_AUTHKEY not set; daemon running but node is unauthenticated"
+    echo "[tailscale] set TS_AUTHKEY in Railway service variables and redeploy"
+  fi
+}
+
+start_tailscale
 
 exec gosu openclaw node src/server.js


### PR DESCRIPTION
## Summary

Adds optional Tailscale support to the Railway template, so deployers can reach the OpenClaw setup wizard / web TUI from their private tailnet (handy when the public URL has issues, or when running OpenClaw in environments where you don't want to expose anything publicly).

- Installs the official `tailscale` Debian package in the image (Bookworm apt repo + GPG key).
- `entrypoint.sh` starts `tailscaled` in **userspace networking** mode (Railway containers don't get `/dev/net/tun`), persisting state on the existing `/data` volume so the tailnet identity survives restarts.
- If `TS_AUTHKEY` is set as a service variable, the entrypoint runs `tailscale up` and (optionally) `tailscale serve` to expose `localhost:$PORT` to the tailnet over HTTPS.
- If `TS_AUTHKEY` is **not** set, the daemon still starts but the node remains unauthenticated, so the image is safe to deploy without changing any existing variables.

## Knobs (all optional service variables)

| Variable | Default | Notes |
|---|---|---|
| `TS_AUTHKEY` | (unset) | Required to actually join a tailnet. Reusable + ephemeral keys recommended for cloud nodes. |
| `TS_HOSTNAME` | `openclaw-railway` | Tailnet hostname for the node. |
| `TS_ACCEPT_DNS` | `false` | Passed through to `tailscale up`. |
| `TS_EXTRA_ARGS` | (empty) | Extra args appended to `tailscale up` (e.g. `--advertise-tags=tag:cloud`). |
| `TS_SERVE_PORT` | `$PORT` | Localhost port forwarded by `tailscale serve`. |
| `TS_SERVE_DISABLED` | `false` | Set to `true` to skip `tailscale serve` (useful if your tailnet doesn't have HTTPS/Funnel enabled — node is still reachable on tailnet IP:`$PORT`). |

## Test plan

- [x] Image builds on Railway with `tailscale` apt package installed.
- [x] Container boots without `TS_AUTHKEY` → wrapper still starts, daemon idles unauthenticated, public URL serves normally.
- [x] Container boots with `TS_AUTHKEY` set → node joins tailnet, appears in `tailscale status`, OpenClaw reachable on tailnet IP at `:$PORT`.
- [x] Container boots with `TS_AUTHKEY` set + `TS_SERVE_DISABLED=true` (for tailnets without HTTPS) → wrapper starts, node joined, no `serve` errors.
- [ ] (For maintainers) Verify `tailscale serve` works on a tailnet with HTTPS enabled.


Made with [Cursor](https://cursor.com)