### PR TITLE
Upgrade OpenClaw to 2026.6.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.6.8
+RUN npm install -g openclaw@2026.6.10
 RUN npm install -g clawhub@latest
 
 WORKDIR /app


### PR DESCRIPTION
Bumps the pinned OpenClaw version in the Dockerfile from `2026.6.8` to `2026.6.10` (latest stable on npm).

- Previous: `openclaw@2026.6.8`
- New: `openclaw@2026.6.10`

Only the Dockerfile pin references the version; no other changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)