### PR TITLE
[codex] Update OpenClaw to 2026.6.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.6.10
+RUN npm install -g openclaw@2026.6.11
 RUN npm install -g clawhub@latest
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

Updates the Docker image build to install OpenClaw `2026.6.11` instead of `2026.6.10`.

## Why

The npm `latest` dist-tag for `openclaw` is now `2026.6.11`, so this keeps the Railway template current with the latest stable OpenClaw release.

## Impact

New Railway image builds will install OpenClaw `2026.6.11` while leaving the rest of the wrapper unchanged.

## Validation

- Verified npm reports `openclaw` latest stable as `2026.6.11`.
- Verified the PR branch Dockerfile contains `RUN npm install -g openclaw@2026.6.11`.

No local build was run; the change is a one-line Docker package pin update.