### PR TITLE
Update OpenClaw to 2026.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.6.11
+RUN npm install -g openclaw@2026.7.1
 RUN npm install -g clawhub@latest
 
 WORKDIR /app


### PR DESCRIPTION
## What changed

- Updated the Docker image to install OpenClaw `2026.7.1` instead of `2026.6.11`.
- Kept the release pinned for reproducible Railway builds.

## Why

`2026.7.1` is the current stable npm `latest` release.

## Impact

New template builds will run OpenClaw `2026.7.1`.

## Validation

- `pnpm lint`
- `pnpm test` (6 tests passed)
- `git diff --check`