### PR TITLE
chore: bump OpenClaw to 2026.7.1-2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.7.1
+RUN npm install -g openclaw@2026.7.1-2
 RUN npm install -g clawhub@latest
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- update the pinned OpenClaw npm package from `2026.7.1` to `2026.7.1-2`
- align the Docker image with the current stable `openclaw@latest` dist-tag

## Verification
- `npm view openclaw@latest version` returns `2026.7.1-2`
- `git diff --check` passes

Docker is unavailable in the orb, so a local image build was not run.