### PR TITLE
chore: update OpenClaw to 2026.7.1-2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.7.1
+RUN npm install -g openclaw@2026.7.1-2
 RUN npm install -g clawhub@latest
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- update the pinned OpenClaw Docker image dependency from 2026.7.1 to 2026.7.1-2
- track npm's current stable `latest` release while excluding the 2026.7.2 beta line

## Verification
- `npm run lint`
- `npm test` (6 tests pass)
- `git diff --check`
- resolved and installed the exact `openclaw@2026.7.1-2` npm artifact with lifecycle scripts disabled

## Notes
- A full Docker build was not run because Docker is unavailable in the orb.