### PR TITLE
v2026.7.1-2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.7.1
+RUN npm install -g openclaw@2026.7.1-2
 RUN npm install -g clawhub@latest
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- release OpenClaw 2026.7.1-2 from staging to main
- update the Dockerfile's pinned stable OpenClaw package from 2026.7.1 to 2026.7.1-2

## Verification
- `npm run lint`
- `npm test` (6 tests passed)
- exact `openclaw@2026.7.1-2` npm artifact resolved successfully

## Checklist
- [x] Changes preserve existing wrapper functionality
- [ ] Tested with an existing volume
- [ ] Tested with a fresh volume