### PR TITLE
Update OpenClaw to 2026.8.1 and Node 26

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -106,9 +106,9 @@ When the user runs setup (src/server.js:522-693):
 
 1. Calls `openclaw onboard --non-interactive` with user-selected auth provider
 2. Writes channel configs (Telegram/Discord/Slack) directly to `openclaw.json` via `openclaw config set --json`
-3. Force-sets gateway config to use token auth + loopback bind + allowInsecureAuth
+3. Force-sets gateway config to use token auth + loopback bind + trusted proxy/origin settings
 4. Spawns gateway process
-5. Waits for gateway readiness (polls multiple endpoints)
+5. Waits for gateway traffic admission at `/startupz`
 
 **Important**: Channel setup bypasses `openclaw channels add` and writes config directly because `channels add` is flaky across different OpenClaw builds.
 
@@ -121,7 +121,7 @@ The wrapper **always** injects the bearer token into proxied requests so browser
 
 **Important**: Token injection uses `http-proxy` event handlers (`proxyReq` and `proxyReqWs`) rather than direct `req.headers` modification. Direct header modification does not reliably work with WebSocket upgrades, causing intermittent `token_missing` or `token_mismatch` errors.
 
-This allows the Control UI at `/openclaw` to work without user authentication.
+This lets the Control UI at `/openclaw` authenticate through the wrapper. New browser devices still require one-time approval from the password-protected setup page.
 
 ## Common Development Tasks
 
@@ -163,7 +163,7 @@ Edit `buildOnboardArgs()` (src/server.js:442-496) to add new CLI flags or auth p
 - Template must mount a volume at `/data`
 - Must set `SETUP_PASSWORD` in Railway Variables
 - Public networking must be enabled (assigns `*.up.railway.app` domain)
-- OpenClaw is installed via `npm install -g openclaw@latest` during Docker build
+- OpenClaw is installed via `npm install -g openclaw@2026.8.1` during Docker build
 
 ## Serena Semantic Coding
 
@@ -190,9 +190,10 @@ This avoids repeatedly reading large files and provides instant context about th
 
 1. **Gateway token must be stable across redeploys** → persisted to volume if not in env
 2. **Channels are written via `config set --json`, not `channels add`** → avoids CLI version incompatibilities
-3. **Gateway readiness check polls multiple endpoints** (`/openclaw`, `/`, `/health`) → some builds only expose certain routes (src/server.js:92)
+3. **Gateway traffic admission uses `/startupz`** → this keeps the UI available when a channel-specific `/readyz` check is unhealthy
 4. **Discord bots require MESSAGE CONTENT INTENT** → document this in setup wizard (src/server.js:295-298)
 5. **Gateway spawn inherits stdio** → logs appear in wrapper output (src/server.js:134)
 6. **WebSocket auth requires proxy event handlers** → Direct `req.headers` modification doesn't work for WebSocket upgrades with http-proxy; must use `proxyReqWs` event (src/server.js:741) to reliably inject Authorization header
-7. **Control UI requires allowInsecureAuth to bypass pairing** → Set `gateway.controlUi.allowInsecureAuth=true` during onboarding to prevent "disconnected (1008): pairing required" errors (GitHub issue #2284). Wrapper already handles bearer token auth, so device pairing is unnecessary.
-8. **Config Editor (`/setup/config`) writes `openclaw.json` directly** → unlike onboarding (which uses `openclaw config set --json`), the editor parses+validates JSON, makes a `.bak-<timestamp>` copy, then `fs.writeFileSync`s the new contents and calls `restartGateway()`. This is intentional: it's an operator-targeted advanced tool, so direct writes are simpler and let users fix arbitrarily-broken config without depending on the CLI.
+7. **Control UI devices require pairing** → `gateway.controlUi.allowInsecureAuth` was retired in OpenClaw 2026.8.1. Approve new browser devices from the password-protected `/setup` page.
+8. **The wrapper is the external supervisor** → `OPENCLAW_SUPERVISOR_MODE=external` prevents OpenClaw service commands and self-updates from competing with Railway and the wrapper's direct child-process lifecycle.
+9. **Config Editor (`/setup/config`) writes `openclaw.json` directly** → unlike onboarding (which uses `openclaw config set --json`), the editor parses+validates JSON, makes a `.bak-<timestamp>` copy, then `fs.writeFileSync`s the new contents and calls `restartGateway()`. This is intentional: it's an operator-targeted advanced tool, so direct writes are simpler and let users fix arbitrarily-broken config without depending on the CLI.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-bookworm
+FROM node:26-bookworm
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -14,13 +14,18 @@ RUN apt-get update \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.7.1-2
+RUN npm install -g \
+    --allow-scripts=openclaw \
+    openclaw@2026.8.1 \
+  && node --version | grep -Eq '^v26\.' \
+  && openclaw --version | grep -Eq '^OpenClaw 2026\.8\.1( |$)'
 RUN npm install -g clawhub@latest
 
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
-RUN corepack enable && pnpm install --frozen-lockfile --prod
+RUN npm install -g pnpm@11.24.0 \
+  && pnpm install --frozen-lockfile --prod
 
 COPY src ./src
 COPY --chmod=755 entrypoint.sh ./entrypoint.sh
@@ -40,6 +45,7 @@ ENV HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew"
 
 ENV PORT=8080
 ENV OPENCLAW_ENTRY=/usr/local/lib/node_modules/openclaw/dist/entry.js
+ENV OPENCLAW_SUPERVISOR_MODE=external
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A: Visit `/setup` on your deployed instance at any time — it works both before
 
 **Q: My config seems broken or I'm getting strange errors. How do I fix it?**
 
-A: Go to `/setup` and click the "Run Doctor" button. This runs `openclaw doctor --repair` which performs health checks on your gateway and channels, creates a backup of your config, and removes any unrecognized or corrupted configuration keys.
+A: Go to `/setup` and click the "Run Doctor" button. This runs `openclaw doctor --fix` which performs health checks on your gateway and channels, creates a backup of your config, and removes any unrecognized or corrupted configuration keys.
 
 ## Screenshots
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=24"
+    "node": ">=26 <27"
   },
   "scripts": {
     "dev": "node src/server.js",

--- a/src/gateway-readiness.js
+++ b/src/gateway-readiness.js
@@ -3,6 +3,10 @@ export function canServeGatewayRequest({ configured, reachable }) {
   return reachable;
 }
 
+export function isGatewayStartupReady(status) {
+  return status >= 200 && status < 300;
+}
+
 export function describeGatewayHealth({
   configured,
   hasProcessHandle,

--- a/src/gateway-readiness.test.mjs
+++ b/src/gateway-readiness.test.mjs
@@ -4,7 +4,20 @@ import test from "node:test";
 import {
   canServeGatewayRequest,
   describeGatewayHealth,
+  isGatewayStartupReady,
 } from "./gateway-readiness.js";
+
+test("accepts successful startup probe responses", () => {
+  assert.equal(isGatewayStartupReady(200), true);
+  assert.equal(isGatewayStartupReady(204), true);
+});
+
+test("rejects redirects, auth errors, missing routes, and server errors", () => {
+  assert.equal(isGatewayStartupReady(302), false);
+  assert.equal(isGatewayStartupReady(401), false);
+  assert.equal(isGatewayStartupReady(404), false);
+  assert.equal(isGatewayStartupReady(503), false);
+});
 
 test("serves gateway requests when a detached gateway is reachable", () => {
   assert.equal(

--- a/src/public/setup.html
+++ b/src/public/setup.html
@@ -57,9 +57,8 @@
 
       get authRequiresSecret() {
         return ![
-          'openai-codex-device-code',
+          'openai-device-code',
           'xai-device-code',
-          'google-gemini-cli',
           'github-copilot',
           'ollama',
           'vllm',
@@ -69,7 +68,7 @@
 
       get isDeviceCode() {
         return [
-          'openai-codex-device-code',
+          'openai-device-code',
           'xai-device-code'
         ].includes(this.selectedAuth);
       },

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ import httpProxy from "http-proxy";
 import {
   canServeGatewayRequest,
   describeGatewayHealth,
+  isGatewayStartupReady,
 } from "./gateway-readiness.js";
 
 const PORT = Number.parseInt(process.env.PORT ?? "8080", 10);
@@ -96,6 +97,7 @@ function resolveGatewayToken() {
 
 const OPENCLAW_GATEWAY_TOKEN = resolveGatewayToken();
 process.env.OPENCLAW_GATEWAY_TOKEN = OPENCLAW_GATEWAY_TOKEN;
+process.env.OPENCLAW_SUPERVISOR_MODE = "external";
 
 let cachedOpenclawVersion = null;
 
@@ -266,35 +268,76 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-async function probeGatewayOnce(opts = {}) {
-  const endpoints = ["/openclaw", "/", "/health"];
-  const timeoutMs = opts.timeoutMs ?? 2000;
+function hasChildExited(proc) {
+  return proc.exitCode !== null || proc.signalCode !== null;
+}
 
-  for (const endpoint of endpoints) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      const res = await fetch(`${GATEWAY_TARGET}${endpoint}`, {
-        method: "GET",
-        signal: controller.signal,
-      });
-      if (res.status < 500) {
-        return { ok: true, endpoint };
-      }
-    } catch (err) {
-      if (
-        err.name !== "AbortError" &&
-        err.code !== "ECONNREFUSED" &&
-        err.cause?.code !== "ECONNREFUSED"
-      ) {
-        const msg = err.code || err.message;
-        if (msg !== "fetch failed" && msg !== "UND_ERR_CONNECT_TIMEOUT") {
-          log.warn("gateway", `health check error: ${msg}`);
+function waitForChildExit(proc, timeoutMs) {
+  if (hasChildExited(proc)) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    const onExit = () => {
+      clearTimeout(timeout);
+      resolve(true);
+    };
+    const timeout = setTimeout(() => {
+      proc.off("exit", onExit);
+      resolve(false);
+    }, timeoutMs);
+    proc.once("exit", onExit);
+  });
+}
+
+async function stopGatewayProcess() {
+  const proc = gatewayProc;
+  if (!proc) return;
+
+  intentionalRestart = true;
+  try {
+    if (!hasChildExited(proc)) {
+      proc.kill("SIGTERM");
+      if (!(await waitForChildExit(proc, 2000))) {
+        log.warn("gateway", "did not stop after SIGTERM; sending SIGKILL");
+        proc.kill("SIGKILL");
+        if (!(await waitForChildExit(proc, 2000))) {
+          throw new Error("Gateway did not stop after SIGKILL");
         }
       }
-    } finally {
-      clearTimeout(timeout);
     }
+  } finally {
+    if (gatewayProc === proc && hasChildExited(proc)) gatewayProc = null;
+    intentionalRestart = false;
+  }
+}
+
+async function probeGatewayOnce(opts = {}) {
+  const endpoint = "/startupz";
+  const timeoutMs = opts.timeoutMs ?? 2000;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${GATEWAY_TARGET}${endpoint}`, {
+      method: "GET",
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    if (isGatewayStartupReady(res.status)) {
+      return { ok: true, endpoint };
+    }
+  } catch (err) {
+    if (
+      err.name !== "AbortError" &&
+      err.code !== "ECONNREFUSED" &&
+      err.cause?.code !== "ECONNREFUSED"
+    ) {
+      const msg = err.code || err.message;
+      if (msg !== "fetch failed" && msg !== "UND_ERR_CONNECT_TIMEOUT") {
+        log.warn("gateway", `startup check error: ${msg}`);
+      }
+    }
+  } finally {
+    clearTimeout(timeout);
   }
 
   return { ok: false, endpoint: null };
@@ -323,9 +366,6 @@ async function startGateway() {
   fs.mkdirSync(STATE_DIR, { recursive: true });
   fs.mkdirSync(WORKSPACE_DIR, { recursive: true });
 
-  const stopResult = await runCmd(OPENCLAW_NODE, clawArgs(["gateway", "stop"]));
-  log.info("gateway", `stop existing gateway exit=${stopResult.code}`);
-
   const args = [
     "gateway",
     "run",
@@ -343,7 +383,7 @@ async function startGateway() {
   ];
 
   gatewayLastStartTime = Date.now();
-  gatewayProc = childProcess.spawn(OPENCLAW_NODE, clawArgs(args), {
+  const proc = childProcess.spawn(OPENCLAW_NODE, clawArgs(args), {
     stdio: "inherit",
     env: {
       ...process.env,
@@ -351,6 +391,7 @@ async function startGateway() {
       OPENCLAW_WORKSPACE_DIR: WORKSPACE_DIR,
     },
   });
+  gatewayProc = proc;
 
   const safeArgs = args.map((arg, i) =>
     args[i - 1] === "--token" ? "[REDACTED]" : arg
@@ -360,16 +401,22 @@ async function startGateway() {
   log.info("gateway", `WORKSPACE_DIR: ${WORKSPACE_DIR}`);
   log.info("gateway", `config path: ${configPath()}`);
 
-  gatewayProc.on("error", (err) => {
+  proc.on("error", (err) => {
     log.error("gateway", `spawn error: ${String(err)}`);
-    gatewayProc = null;
+    if (gatewayProc === proc) gatewayProc = null;
   });
 
-  gatewayProc.on("exit", (code, signal) => {
+  proc.on("exit", (code, signal) => {
     log.error("gateway", `exited code=${code} signal=${signal}`);
     const uptime = Date.now() - gatewayLastStartTime;
-    gatewayProc = null;
-    if (!shuttingDown && !intentionalRestart && isConfigured()) {
+    const wasCurrentProcess = gatewayProc === proc;
+    if (wasCurrentProcess) gatewayProc = null;
+    if (
+      wasCurrentProcess &&
+      !shuttingDown &&
+      !intentionalRestart &&
+      isConfigured()
+    ) {
       if (uptime > 30_000) {
         gatewayRestartCount = 0;
       } else {
@@ -432,18 +479,7 @@ function isGatewayReady() {
 }
 
 async function restartGateway() {
-  if (gatewayProc) {
-    intentionalRestart = true;
-    try {
-      gatewayProc.kill("SIGTERM");
-    } catch (err) {
-      log.warn("gateway", `kill error: ${err.message}`);
-    }
-    await sleep(750);
-    gatewayProc = null;
-    intentionalRestart = false;
-  }
-  await runCmd(OPENCLAW_NODE, clawArgs(["gateway", "stop"]));
+  await stopGatewayProcess();
   gatewayRestartCount = 0;
   return ensureGatewayRunning();
 }
@@ -623,8 +659,8 @@ app.get("/setup/api/status", requireSetupAuth, async (_req, res) => {
       options: [
         { value: "openai-api-key", label: "OpenAI API key" },
         {
-          value: "openai-codex-device-code",
-          label: "OpenAI Codex device pairing",
+          value: "openai-device-code",
+          label: "ChatGPT device pairing",
           hint: "ChatGPT login without an API key",
         },
       ],
@@ -632,10 +668,9 @@ app.get("/setup/api/status", requireSetupAuth, async (_req, res) => {
     {
       value: "google",
       label: "Google",
-      hint: "API key / CLI",
+      hint: "API key",
       options: [
         { value: "gemini-api-key", label: "Google Gemini API key" },
-        { value: "google-gemini-cli", label: "Google Gemini CLI (OAuth)" },
       ],
     },
     {
@@ -730,19 +765,13 @@ app.get("/setup/api/status", requireSetupAuth, async (_req, res) => {
     },
     {
       value: "qwen",
-      label: "Qwen",
-      hint: "OAuth",
-      options: [{ value: "qwen-portal", label: "Qwen OAuth" }],
-    },
-    {
-      value: "modelstudio",
-      label: "Alibaba Model Studio",
-      hint: "Qwen via Alibaba Cloud",
+      label: "Qwen Cloud",
+      hint: "Standard / Coding Plan",
       options: [
-        { value: "modelstudio-api-key", label: "Coding Plan (Global)" },
-        { value: "modelstudio-api-key-cn", label: "Coding Plan (CN)" },
-        { value: "modelstudio-standard-api-key", label: "Standard Plan (Global)" },
-        { value: "modelstudio-standard-api-key-cn", label: "Standard Plan (CN)" },
+        { value: "qwen-api-key", label: "Coding Plan (Global)" },
+        { value: "qwen-api-key-cn", label: "Coding Plan (CN)" },
+        { value: "qwen-standard-api-key", label: "Standard Plan (Global)" },
+        { value: "qwen-standard-api-key-cn", label: "Standard Plan (CN)" },
       ],
     },
     {
@@ -857,6 +886,8 @@ function buildOnboardArgs(payload) {
   const args = [
     "onboard",
     "--accept-risk",
+    "--mode",
+    "local",
     "--no-install-daemon",
     "--skip-health",
     "--workspace",
@@ -895,10 +926,10 @@ function buildOnboardArgs(payload) {
       "minimax-global-api": "--minimax-api-key",
       "minimax-cn-api": "--minimax-api-key",
       "zai-api-key": "--zai-api-key",
-      "modelstudio-api-key": "--modelstudio-api-key",
-      "modelstudio-api-key-cn": "--modelstudio-api-key-cn",
-      "modelstudio-standard-api-key": "--modelstudio-standard-api-key",
-      "modelstudio-standard-api-key-cn": "--modelstudio-standard-api-key-cn",
+      "qwen-api-key": "--modelstudio-api-key",
+      "qwen-api-key-cn": "--modelstudio-api-key-cn",
+      "qwen-standard-api-key": "--modelstudio-standard-api-key",
+      "qwen-standard-api-key-cn": "--modelstudio-standard-api-key-cn",
       "venice-api-key": "--venice-api-key",
       "chutes-api-key": "--chutes-api-key",
       "kilocode-api-key": "--kilocode-api-key",
@@ -974,10 +1005,8 @@ function runCmd(cmd, args, opts = {}) {
 const VALID_AUTH_CHOICES = [
   "apiKey",
   "openai-api-key",
-  "openai-codex",
-  "openai-codex-device-code",
+  "openai-device-code",
   "gemini-api-key",
-  "google-gemini-cli",
   "deepseek-api-key",
   "openrouter-api-key",
   "xai-api-key",
@@ -999,11 +1028,10 @@ const VALID_AUTH_CHOICES = [
   "zai-coding-cn",
   "zai-global",
   "zai-cn",
-  "qwen-portal",
-  "modelstudio-api-key",
-  "modelstudio-api-key-cn",
-  "modelstudio-standard-api-key",
-  "modelstudio-standard-api-key-cn",
+  "qwen-api-key",
+  "qwen-api-key-cn",
+  "qwen-standard-api-key",
+  "qwen-standard-api-key-cn",
   "venice-api-key",
   "chutes",
   "chutes-api-key",
@@ -1028,8 +1056,7 @@ const VALID_AUTH_CHOICES = [
 // can't be driven from the web wizard — direct the operator to run
 // `openclaw wizard` from the Railway console instead.
 const RAILWAY_CONSOLE_AUTH_CHOICES = [
-  "openai-codex",
-  "openai-codex-device-code",
+  "openai-device-code",
   "xai-device-code",
 ];
 
@@ -1101,19 +1128,6 @@ app.post("/setup/api/run", requireSetupAuth, async (req, res) => {
 
     if (ok) {
       stream("\n[setup] Configuring gateway settings...\n");
-
-      const allowInsecureResult = await runCmd(
-        OPENCLAW_NODE,
-        clawArgs([
-          "config",
-          "set",
-          "gateway.controlUi.allowInsecureAuth",
-          "true",
-        ]),
-      );
-      stream(
-        `[config] gateway.controlUi.allowInsecureAuth=true exit=${allowInsecureResult.code}\n`,
-      );
 
       const tokenResult = await runCmd(
         OPENCLAW_NODE,
@@ -1299,14 +1313,7 @@ app.post("/setup/api/pairing/approve", requireSetupAuth, async (req, res) => {
 
 app.post("/setup/api/reset", requireSetupAuth, async (_req, res) => {
   try {
-    if (gatewayProc) {
-      intentionalRestart = true;
-      gatewayProc.kill("SIGTERM");
-      await sleep(750);
-      gatewayProc = null;
-      intentionalRestart = false;
-    }
-    await runCmd(OPENCLAW_NODE, clawArgs(["gateway", "stop"]));
+    await stopGatewayProcess();
     fs.rmSync(configPath(), { force: true });
     res
       .type("text/plain")
@@ -1317,7 +1324,7 @@ app.post("/setup/api/reset", requireSetupAuth, async (_req, res) => {
 });
 
 app.post("/setup/api/doctor", requireSetupAuth, async (_req, res) => {
-  const args = ["doctor", "--non-interactive", "--repair"];
+  const args = ["doctor", "--non-interactive", "--fix"];
   const result = await runCmd(OPENCLAW_NODE, clawArgs(args));
   return res.status(result.code === 0 ? 200 : 500).json({
     ok: result.code === 0,
@@ -1634,18 +1641,8 @@ app.post(
 
       // Now that the archive is fully extracted and validated, take down the
       // gateway. From here through the rename swap, downtime is unavoidable.
-      if (gatewayProc) {
-        intentionalRestart = true;
-        try {
-          gatewayProc.kill("SIGTERM");
-        } catch (err) {
-          log.warn("import", `kill error: ${err.message}`);
-        }
-        await sleep(750);
-        gatewayProc = null;
-        intentionalRestart = false;
-        gatewayWasStopped = true;
-      }
+      gatewayWasStopped = gatewayProc !== null;
+      if (gatewayWasStopped) await stopGatewayProcess();
 
       for (const { target, source } of validReplacements) {
         const backup = `${target}.bak-${ts}`;
@@ -1847,26 +1844,10 @@ async function gracefulShutdown(signal) {
 
   server.close();
 
-  if (gatewayProc) {
-    try {
-      gatewayProc.kill("SIGTERM");
-      await Promise.race([
-        new Promise((resolve) => gatewayProc.on("exit", resolve)),
-        new Promise((resolve) => setTimeout(resolve, 2000)),
-      ]);
-      if (gatewayProc && !gatewayProc.killed) {
-        gatewayProc.kill("SIGKILL");
-      }
-    } catch (err) {
-      log.warn("wrapper", `error killing gateway: ${err.message}`);
-    }
-  }
-
   try {
-    const stopResult = await runCmd(OPENCLAW_NODE, clawArgs(["gateway", "stop"]));
-    log.info("wrapper", `gateway stop during shutdown exit=${stopResult.code}`);
+    await stopGatewayProcess();
   } catch (err) {
-    log.warn("wrapper", `gateway stop during shutdown failed: ${err.message}`);
+    log.warn("wrapper", `error stopping gateway: ${err.message}`);
   }
 
   process.exit(0);


### PR DESCRIPTION
## Summary

- upgrade OpenClaw from 2026.7.1-2 to 2026.8.1 and move the image to the recommended Node 26 runtime
- adapt onboarding provider IDs, retired Control UI settings, Doctor flags, and Gateway readiness to the 2026.8.1 contracts
- run the wrapper as OpenClaw's external supervisor and manage the Gateway child directly, including safe import/restart shutdown
- replace removed Corepack with pinned pnpm 11.24.0 and allow only OpenClaw's required npm lifecycle scripts

## Verification

- Docker image builds with Node 26.8.1 and OpenClaw 2026.8.1
- web onboarding and generated Gateway config pass in an isolated container
- HTTP health/readiness, Control UI proxying, and WebSocket `connect.challenge` pass
- export/import replaces the old Gateway process and restores readiness
- graceful SIGTERM shutdown passes
- `npm test` — 8 passing
- `npm run lint`
- Oracle review completed; both findings addressed