### PR TITLE
Fix OpenClaw proxy attribution

### DIFF
--- a/src/proxy-headers.js
+++ b/src/proxy-headers.js
@@ -1,0 +1,50 @@
+import net from "node:net";
+
+function validForwardedHost(value, fallback) {
+  if (typeof value !== "string" || value.includes(",")) return fallback;
+
+  try {
+    const url = new URL(`https://${value.trim()}`);
+    if (
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash ||
+      url.username ||
+      url.password
+    ) {
+      return fallback;
+    }
+    return url.host;
+  } catch {
+    return fallback;
+  }
+}
+
+export function rebuildForwardedHeaders(proxyReq, req, railwayPublicDomain) {
+  for (const name of proxyReq.getHeaderNames()) {
+    const lower = name.toLowerCase();
+    if (
+      lower === "forwarded" ||
+      lower === "x-real-ip" ||
+      lower.startsWith("x-forwarded-")
+    ) {
+      proxyReq.removeHeader(name);
+    }
+  }
+
+  if (!railwayPublicDomain) return;
+
+  const realIp = req.headers["x-real-ip"];
+  const clientIp =
+    typeof realIp === "string" && net.isIP(realIp.trim())
+      ? realIp.trim()
+      : "127.0.0.1";
+  const forwardedHost = validForwardedHost(
+    req.headers["x-forwarded-host"],
+    railwayPublicDomain,
+  );
+
+  proxyReq.setHeader("X-Forwarded-For", clientIp);
+  proxyReq.setHeader("X-Forwarded-Proto", "https");
+  proxyReq.setHeader("X-Forwarded-Host", forwardedHost);
+}

--- a/src/proxy-headers.test.mjs
+++ b/src/proxy-headers.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rebuildForwardedHeaders } from "./proxy-headers.js";
+
+function proxyRequest(headers) {
+  const values = new Map(
+    Object.entries(headers).map(([name, value]) => [name.toLowerCase(), value]),
+  );
+  return {
+    getHeaderNames: () => [...values.keys()],
+    removeHeader: (name) => values.delete(name.toLowerCase()),
+    setHeader: (name, value) => values.set(name.toLowerCase(), value),
+    headers: values,
+  };
+}
+
+test("rebuilds Railway forwarding headers from the trusted client IP", () => {
+  const proxyReq = proxyRequest({
+    forwarded: "for=192.0.2.1",
+    "x-forwarded-for": "192.0.2.1",
+    "x-forwarded-proto": "http",
+    "x-forwarded-host": "claw.example.com",
+    "x-forwarded-client-cert": "spoofed",
+    "x-real-ip": "192.0.2.1",
+  });
+
+  rebuildForwardedHeaders(
+    proxyReq,
+    {
+      headers: {
+        host: "internal.railway",
+        "x-forwarded-host": "claw.example.com",
+        "x-real-ip": "203.0.113.10",
+      },
+      socket: { remoteAddress: "100.64.0.1" },
+    },
+    "claw.up.railway.app",
+  );
+
+  assert.deepEqual(Object.fromEntries(proxyReq.headers), {
+    "x-forwarded-for": "203.0.113.10",
+    "x-forwarded-proto": "https",
+    "x-forwarded-host": "claw.example.com",
+  });
+});
+
+test("fails closed when Railway client attribution is missing or malformed", () => {
+  for (const realIp of [undefined, "not-an-ip"]) {
+    const proxyReq = proxyRequest({});
+    rebuildForwardedHeaders(
+      proxyReq,
+      {
+        headers: {
+          "x-forwarded-host": "invalid.example.com, spoofed.example.com",
+          ...(realIp === undefined ? {} : { "x-real-ip": realIp }),
+        },
+        socket: { remoteAddress: "100.64.0.1" },
+      },
+      "claw.up.railway.app",
+    );
+
+    assert.deepEqual(Object.fromEntries(proxyReq.headers), {
+      "x-forwarded-for": "127.0.0.1",
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "claw.up.railway.app",
+    });
+  }
+});
+
+test("keeps loopback client attribution fail-closed for OpenClaw", () => {
+  const proxyReq = proxyRequest({});
+  rebuildForwardedHeaders(
+    proxyReq,
+    {
+      headers: { "x-real-ip": "::1" },
+      socket: { remoteAddress: "100.64.0.1" },
+    },
+    "claw.up.railway.app",
+  );
+
+  assert.equal(proxyReq.headers.get("x-forwarded-for"), "::1");
+});
+
+test("strips untrusted forwarding headers outside Railway", () => {
+  const proxyReq = proxyRequest({
+    "x-forwarded-for": "192.0.2.1",
+    "x-real-ip": "192.0.2.1",
+  });
+
+  rebuildForwardedHeaders(
+    proxyReq,
+    {
+      headers: { "x-real-ip": "192.0.2.1" },
+      socket: { remoteAddress: "127.0.0.1" },
+    },
+    undefined,
+  );
+
+  assert.deepEqual(Object.fromEntries(proxyReq.headers), {});
+});

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ import {
   describeGatewayHealth,
   isGatewayStartupReady,
 } from "./gateway-readiness.js";
+import { rebuildForwardedHeaders } from "./proxy-headers.js";
 
 const PORT = Number.parseInt(process.env.PORT ?? "8080", 10);
 const STATE_DIR =
@@ -257,6 +258,39 @@ async function syncAllowedOrigins() {
   }
 }
 
+async function syncTrustedProxies() {
+  const expected = ["127.0.0.1", "::1"];
+  const current = await runCmd(
+    OPENCLAW_NODE,
+    clawArgs(["config", "get", "gateway.trustedProxies"]),
+  );
+
+  try {
+    if (
+      current.code === 0 &&
+      JSON.stringify(JSON.parse(stripAnsi(current.output).trim())) ===
+        JSON.stringify(expected)
+    ) {
+      return;
+    }
+  } catch {}
+
+  const result = await runCmd(
+    OPENCLAW_NODE,
+    clawArgs([
+      "config",
+      "set",
+      "--json",
+      "gateway.trustedProxies",
+      JSON.stringify(expected),
+    ]),
+  );
+  if (result.code !== 0) {
+    throw new Error(`Failed to set gateway.trustedProxies (exit=${result.code})`);
+  }
+  log.info("gateway", `set trustedProxies to ${JSON.stringify(expected)}`);
+}
+
 let gatewayProc = null;
 let gatewayStarting = null;
 let shuttingDown = false;
@@ -456,6 +490,7 @@ async function ensureGatewayRunning() {
   }
   if (!gatewayStarting) {
     gatewayStarting = (async () => {
+      await syncTrustedProxies();
       await syncAllowedOrigins();
       await startGateway();
       const ready = await waitForGatewayReady({ timeoutMs: 60_000 });
@@ -1140,18 +1175,6 @@ app.post("/setup/api/run", requireSetupAuth, async (req, res) => {
       );
       stream(`[config] gateway.auth.token exit=${tokenResult.code}\n`);
 
-      const proxiesResult = await runCmd(
-        OPENCLAW_NODE,
-        clawArgs([
-          "config",
-          "set",
-          "--json",
-          "gateway.trustedProxies",
-          '["127.0.0.1"]',
-        ]),
-      );
-      stream(`[config] gateway.trustedProxies exit=${proxiesResult.code}\n`);
-
       if (payload.model?.trim()) {
         stream(`[setup] Setting model to ${payload.model.trim()}...\n`);
         const modelResult = await runCmd(
@@ -1717,7 +1740,6 @@ app.get("/setup/api/logs/stream", requireSetupAuth, (req, res) => {
 const proxy = httpProxy.createProxyServer({
   target: GATEWAY_TARGET,
   ws: true,
-  xfwd: true,
   changeOrigin: true,
   proxyTimeout: 120_000,
   timeout: 120_000,
@@ -1748,11 +1770,21 @@ proxy.on("proxyReq", (proxyReq, req, res) => {
     proxyReq.setHeader("Authorization", `Bearer ${OPENCLAW_GATEWAY_TOKEN}`);
   }
   proxyReq.setHeader("Origin", PROXY_ORIGIN);
+  rebuildForwardedHeaders(
+    proxyReq,
+    req,
+    process.env.RAILWAY_PUBLIC_DOMAIN,
+  );
 });
 
 proxy.on("proxyReqWs", (proxyReq, req, socket, options, head) => {
   proxyReq.setHeader("Authorization", `Bearer ${OPENCLAW_GATEWAY_TOKEN}`);
   proxyReq.setHeader("Origin", PROXY_ORIGIN);
+  rebuildForwardedHeaders(
+    proxyReq,
+    req,
+    process.env.RAILWAY_PUBLIC_DOMAIN,
+  );
 });
 
 app.use(async (req, res) => {


### PR DESCRIPTION
## Summary
- sync narrow IPv4/IPv6 loopback trusted proxies before starting OpenClaw
- replace appended forwarding headers with sanitized Railway client attribution for HTTP and WebSockets
- fail closed on invalid client metadata and preserve a validated original forwarded host

## Testing
- `mise exec node@26.7 -- npm test`
- `mise exec node@26.7 -- npm run lint`
- real `http-proxy` forwarding integration check