### PR TITLE
Replace missing logo and update OpenClaw to 2026.8.2

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -163,7 +163,7 @@ Edit `buildOnboardArgs()` (src/server.js:442-496) to add new CLI flags or auth p
 - Template must mount a volume at `/data`
 - Must set `SETUP_PASSWORD` in Railway Variables
 - Public networking must be enabled (assigns `*.up.railway.app` domain)
-- OpenClaw is installed via `npm install -g openclaw@2026.8.1` during Docker build
+- OpenClaw is installed via `npm install -g openclaw@2026.8.2` during Docker build
 
 ## Serena Semantic Coding
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update \
 
 RUN npm install -g \
     --allow-scripts=openclaw \
-    openclaw@2026.8.1 \
+    openclaw@2026.8.2 \
   && node --version | grep -Eq '^v26\.' \
-  && openclaw --version | grep -Eq '^OpenClaw 2026\.8\.1( |$)'
+  && openclaw --version | grep -Eq '^OpenClaw 2026\.8\.2( |$)'
 RUN npm install -g clawhub@latest
 
 WORKDIR /app

--- a/src/public/config.html
+++ b/src/public/config.html
@@ -87,10 +87,7 @@
 <body x-data="configApp()">
   <div class="container">
     <div class="logo-wrap">
-      <picture>
-        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text-dark.png">
-        <img src="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png" alt="OpenClaw" class="logo-img">
-      </picture>
+      <span class="logo-text">OpenClaw 🦞</span>
     </div>
 
     <div style="margin-bottom:1.25rem">

--- a/src/public/loading.html
+++ b/src/public/loading.html
@@ -31,10 +31,7 @@
 <body class="loading-center">
   <div class="loading-inner">
     <div class="logo-wrap">
-      <picture>
-        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text-dark.png">
-        <img src="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png" alt="OpenClaw" class="logo-img-sm">
-      </picture>
+      <span class="logo-text">OpenClaw 🦞</span>
     </div>
 
     <div id="state-loading">

--- a/src/public/setup.html
+++ b/src/public/setup.html
@@ -484,10 +484,7 @@
 <body x-data="setupApp()">
   <div class="container">
     <div class="logo-wrap">
-      <picture>
-        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text-dark.png">
-        <img src="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png" alt="OpenClaw" class="logo-img">
-      </picture>
+      <span class="logo-text">OpenClaw 🦞</span>
     </div>
     <div style="margin-bottom:1.5rem;padding:0.75rem 1rem;border:1px solid #ef4444;border-radius:0.5rem;background:var(--bg-card)">
       <p style="font-size:0.75rem;color:var(--text-mid);line-height:1.5;margin:0">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -59,7 +59,6 @@ body {
 [x-cloak] { display: none !important; }
 
 a { color: inherit; text-decoration: none; }
-img { max-width: 100%; height: auto; }
 
 .container {
   max-width: 48rem;
@@ -74,8 +73,11 @@ img { max-width: 100%; height: auto; }
   margin-bottom: 1.5rem;
 }
 
-.logo-img { max-width: 280px; }
-.logo-img-sm { max-width: 200px; }
+.logo-text {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+}
 
 .page-title {
   font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- replace the removed remote logo with `OpenClaw 🦞` text
- apply the text treatment consistently to setup, config, and loading pages
- update the pinned OpenClaw release from 2026.8.1 to 2026.8.2

## Verification
- `npm run lint`
- `npm test` (12 tests)
- `docker build --progress=plain -t openclaw-railway-template:2026.8.2-test .`
