### PR TITLE
chore: update OpenClaw to 2026.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update \
 
 RUN npm install -g \
     --allow-scripts=openclaw \
-    openclaw@2026.8.2 \
+    openclaw@2026.9.1 \
   && node --version | grep -Eq '^v26\.' \
-  && openclaw --version | grep -Eq '^OpenClaw 2026\.8\.2( |$)'
+  && openclaw --version | grep -Eq '^OpenClaw 2026\.9\.1( |$)'
 RUN npm install -g clawhub@latest
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- update the Docker image to OpenClaw 2026.9.1
- update the build-time CLI version assertion

## Verification
- `npm run lint`
- `npm test` (12 tests passed)
- `npx --yes --package=openclaw@2026.9.1 openclaw --version`

Docker image build was not run because the development orb does not provide a Docker daemon.