### PR TITLE
chore: update OpenClaw to 2026.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update \
 
 RUN npm install -g \
     --allow-scripts=openclaw \
-    openclaw@2026.9.1 \
+    openclaw@2026.9.2 \
   && node --version | grep -Eq '^v26\.' \
-  && openclaw --version | grep -Eq '^OpenClaw 2026\.9\.1( |$)'
+  && openclaw --version | grep -Eq '^OpenClaw 2026\.9\.2( |$)'
 RUN npm install -g clawhub@latest
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Update the Docker image OpenClaw pin from 2026.9.1 to 2026.9.2 (current npm latest).
- Update the build-time version assertion to match.

## Validation
- npm run lint: passed.
- npm test: all 12 tests passed.
- git diff --check: passed.
- Full Docker build not run: Docker daemon is unavailable in the orb.